### PR TITLE
Support new Netflix 'shakti' API and Netflix client side JS structure.

### DIFF
--- a/lib/constants.json
+++ b/lib/constants.json
@@ -37,7 +37,7 @@
   "manageProfilesUrl": "/ManageProfiles",
   "pathEvaluatorEndpointUrl": "/pathEvaluator",
   "profilesEndpointUrl": "/profiles",
-  "ratingHistoryEndpointUrl": "/ratingHistory",
+  "ratingHistoryEndpointUrl": "/ratinghistory",
   "setVideoRatindEndpointUrl": "/setVideoRating",
   "switchProfileEndpointUrl": "/profiles/switch",
   "yourAccountUrl": "/YourAccount"

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -22,6 +22,7 @@ function Netflix (options) {
   }, options)
   this.cookieJar = options.cookieJar
   this.apiBase = ''
+  this.netflixContext = {}
   this.endpointIdentifiers = {}
   this.authUrls = {}
   this.activeProfile = null
@@ -167,7 +168,7 @@ Netflix.prototype.setAvatar = function (avatarName, callback) {
 }
 
 Netflix.prototype.__getEndpoint = function (endpoint) {
-  return endpoint + '/' + this.endpointIdentifiers[endpoint]
+  return endpoint
 }
 
 Netflix.prototype.__apiRequest = function (endpoint, options, callback) {
@@ -272,9 +273,10 @@ Netflix.prototype.__getContextData = function (url, callback) {
       }
     })
 
-    self.apiRoot = context.netflix.contextData.serverDefs.data.SHAKTI_API_ROOT
-    self.endpointIdentifiers = context.netflix.contextData.serverDefs.data.endpointIdentifiers
-    self.authUrls[url] = context.netflix.contextData.userInfo.data.authURL
+    self.netflixContext = context.netflix.reactContext.models
+    self.apiRoot = self.netflixContext.serverDefs.data.SHAKTI_API_ROOT + '/' + self.netflixContext.serverDefs.data.BUILD_IDENTIFIER
+    self.endpointIdentifiers = self.netflixContext.serverDefs.data.endpointIdentifiers
+    self.authUrls[url] = self.netflixContext.userInfo.data.authURL
 
     callback(null)
   })


### PR DESCRIPTION
Fixes genderquery/netflix-migrate#2

API URLs require a build identifier and no endpoint id
Client side JS model has moved to reactContext

For example:
`https://www.netflix.com/api/shakti/ratingHistory/8347ed8da8353156064c4dfcc92232af72ba983a?pg=0`
has changed to
`https://www.netflix.com/api/shakti/0feb190f/ratinghistory?pg=0`

`context.netflix.contextData.serverDefs.data.SHAKTI_API_ROOT`
has changed to
`context.netflix.reactContext.models.serverDefs.data.SHAKTI_API_ROOT`

A very quick fix, I have only tested with netflix-migrate - there may still be some outdated endpoints / methods that are not covered by netflix-migrate.

