### PR TITLE
Fix: "ReferenceError: navigator is not defined"

### DIFF
--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -267,7 +267,8 @@ Netflix.prototype.__getContextData = function (url, callback) {
     }
     var context = {
       window: {},
-      netflix: {}
+      netflix: {},
+      navigator: {}
     }
     vm.createContext(context)
     var $ = cheerio.load(body)


### PR DESCRIPTION
node-netflix2 stopped working, as new code was introduced by Netflix where it tries to access 'serviceWorker' in navigator. This fix mocks the navigator object in the context, so everything works smoothly again.