### PR TITLE
Fix: 'ReferenceError: document is not defined'

### DIFF
--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -267,8 +267,7 @@ Netflix.prototype.__getContextData = function (url, callback) {
     }
     var context = {
       window: {},
-      netflix: {},
-      navigator: {}
+      netflix: {}
     }
     vm.createContext(context)
     var $ = cheerio.load(body)
@@ -276,7 +275,9 @@ Netflix.prototype.__getContextData = function (url, callback) {
       // don't run external scripts
       if (!element.attribs.src) {
         var script = $(element).text()
-        vm.runInContext(script, context)
+        if(script.indexOf('window.netflix') === 0) {
+			    vm.runInContext(script, context);
+		    }
       }
     })
 


### PR DESCRIPTION
Netflix keeps adding code to their scripts that is not important for the inner workings of node-netflix2, breaking it in the progress. I've added a check that only allows scripts to execute that contain the lines we need (starting with 'window.netflix = ').