### PR TITLE
Add functionality for thumb ratings

### DIFF
--- a/lib/constants.json
+++ b/lib/constants.json
@@ -39,6 +39,7 @@
   "profilesEndpointUrl": "/profiles",
   "ratingHistoryEndpointUrl": "/ratinghistory",
   "setVideoRatindEndpointUrl": "/setVideoRating",
+  "setThumbRatingEndpointUrl": "/setThumbRating",
   "switchProfileEndpointUrl": "/profiles/switch",
   "yourAccountUrl": "/YourAccount"
 }

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -88,7 +88,7 @@ Netflix.prototype.switchProfile = function (guid, callback) {
     if (json.status !== 'success') {
       return callback(new Error())
     }
-    self.activeProfile = guid   
+    self.activeProfile = guid
     getContextData()
   })
 }
@@ -119,14 +119,18 @@ Netflix.prototype.getRatingHistory = function (callback) {
   )
 }
 
-Netflix.prototype.setVideoRating = function (titleId, rating, callback) {
-  var endpoint = constants.setVideoRatindEndpointUrl
+Netflix.prototype.__setRating = function (isThumbRating, titleId, rating, callback) {
+  var endpoint = isThumbRating ? constants.setThumbRatingEndpointUrl : constants.setVideoRatindEndpointUrl;
   var options = {
     qs: {
-      titleid: titleId,
       rating: rating,
       authURL: this.authUrls[constants.yourAccountUrl]
     }
+  }
+  if (isThumbRating) {
+    options.qs.titleId = titleId
+  } else {
+    options.qs.titleid = titleId
   }
   this.__apiRequest(endpoint, options, function (error, response, json) {
     if (error) {
@@ -137,6 +141,14 @@ Netflix.prototype.setVideoRating = function (titleId, rating, callback) {
     }
     callback(null)
   })
+}
+
+Netflix.prototype.setVideoRating = function (titleId, rating, callback) {
+  this.__setRating(false, titleId, rating, callback)
+}
+
+Netflix.prototype.setThumbRating = function (titleId, rating, callback) {
+  this.__setRating(true, titleId, rating, callback)
 }
 
 Netflix.prototype.getActiveProfile = function (callback) {


### PR DESCRIPTION
In 2017, netflix changed it's rating system from stars to thumbs. The objects returned in `getRatingHistory` contain information about whether a rating was made as a star or a thumb rating but `setVideoRating` is not able to set a thumb rating.

I added a `setThumbRating` function (and endpoint URL) to do just that. In order to avoid duplicate code, I extracted most of the logic into a helper function (`__setRating`) that is called by both `setVideoRating` and `setThumbRating`. I also noticed, that the setThumbRating endpoint expects a titleId (upper-case i) whereas the setVideoRating endpoint expects a titleid (lower-case i), which is also considered in the code.