### PR TITLE
Fix login

### DIFF
--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -88,7 +88,7 @@ Netflix.prototype.switchProfile = function (guid, callback) {
     if (json.status !== 'success') {
       return callback(new Error())
     }
-    self.activeProfile = guid   
+    self.activeProfile = guid
     getContextData()
   })
 }
@@ -223,7 +223,7 @@ Netflix.prototype.__getLoginForm = function (credentials, callback) {
         obj[pair.name] = pair.value
         return obj
       }, {})
-    form.email = credentials.email
+    form.userLoginId = credentials.email
     form.password = credentials.password
     callback(null, form)
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix2",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "description": "A client library to access the not-so-public Netflix Shakti API.",
   "keywords": [
     "netflix",


### PR DESCRIPTION
Netflix changed the name of the email input field of the login form from email to userLoginId and thus broke our login function. This PR fixes that.