### PR TITLE
Fix login for former members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+testNewFeature.js

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -403,7 +403,7 @@ Netflix.prototype.__getContextData = function (url, callback) {
       self.endpointIdentifiers = self.netflixContext.serverDefs.data.endpointIdentifiers
     } else if (context.netflix.contextData) {
       self.netflixContext = context.netflix.contextData
-      self.apiRoot = 'https://www.netflix.com/api/shakti/' + context.netflix.serverDefs.BUILD_IDENTIFIER
+      self.apiRoot = 'https://www.netflix.com/api/shakti/' + context.netflix.contextData.serverDefs.BUILD_IDENTIFIER
       self.endpointIdentifiers = {}
       self.authUrls[url] = context.netflix.contextData.authURL
     } else {

--- a/lib/netflix2.js
+++ b/lib/netflix2.js
@@ -390,11 +390,28 @@ Netflix.prototype.__getContextData = function (url, callback) {
         }
       }
     })
-
-    self.netflixContext = context.netflix.reactContext.models
-    self.apiRoot = self.netflixContext.serverDefs.data.SHAKTI_API_ROOT + '/' + self.netflixContext.serverDefs.data.BUILD_IDENTIFIER
-    self.endpointIdentifiers = self.netflixContext.serverDefs.data.endpointIdentifiers
-    self.authUrls[url] = self.netflixContext.userInfo.data.authURL
+    /*
+     * For some reason, context.netflix.reactContext does not always exist. The cause may be wether an account is active
+     * or not, but that is not for sure.
+     *
+     * Currently, this fixes the issue, as the shakti API root seems to always be identical and endpointIdentifiers
+     * seem to always be an empty object. This is a quick and dirty fix due to lack of more information!
+     */
+    if (context.netflix.reactContext) {
+      self.netflixContext = context.netflix.reactContext.models
+      self.apiRoot = self.netflixContext.serverDefs.data.SHAKTI_API_ROOT + '/' + self.netflixContext.serverDefs.data.BUILD_IDENTIFIER
+      self.endpointIdentifiers = self.netflixContext.serverDefs.data.endpointIdentifiers
+    } else if (context.netflix.contextData) {
+      self.netflixContext = context.netflix.contextData
+      self.apiRoot = 'https://www.netflix.com/api/shakti/' + context.netflix.serverDefs.BUILD_IDENTIFIER
+      self.endpointIdentifiers = {}
+      self.authUrls[url] = context.netflix.contextData.authURL
+    } else {
+      throw new Error(
+        'An error occurred that appears to be similar to ' +
+        'https://github.com/genderquery/netflix-migrate/issues/24 !'
+      )
+    }
 
     callback(null)
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix2",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A client library to access the not-so-public Netflix Shakti API.",
   "keywords": [
     "netflix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix2",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A client library to access the not-so-public Netflix Shakti API.",
   "keywords": [
     "netflix",


### PR DESCRIPTION
In [this issue](https://github.com/genderquery/netflix-migrate/issues/24) a user had a problem with logging into his account. He gave me access to his account and I noticed that it wasn't active any more. I then took a deeper look into the issue itsself and noticed that after the request to ".../ManageProfiles" the `context.netflix.reactContext` was not set, but instead there was a `context.netflix.contextData` object that contained most of the needed data.

My theory is that this has to do with the account being inactive, but I have no additional arguments to support that theory.