### PR TITLE
Re-publish 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix2",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A client library to access the not-so-public Netflix Shakti API.",
   "keywords": [
     "netflix",


### PR DESCRIPTION
I messed up and accidentally published the (old) master branch instead of the feature branch, so I had to re-publish the version.